### PR TITLE
Add compatibility with php8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         }
     },
     "require": {
-        "php": "^7.2",
+        "php": "^7.2|^8.0",
         "illuminate/database": "^6.0|^7.0|^8.0",
         "paragonie/ciphersweet": "^2"
     },


### PR DESCRIPTION
Hello,
I want to add php80 compatibility to prevent composer errors when requiring this package. I checked the compatibility with php code sniffer. And all non dev dependencies seem to be compatible with php80.